### PR TITLE
[Motion Sensor with Switch Driver] Automatic-Inactive Toggle

### DIFF
--- a/drivers/virtual-motion-sensor-with-switch.groovy
+++ b/drivers/virtual-motion-sensor-with-switch.groovy
@@ -36,6 +36,8 @@ metadata {
       title: "Inactive Delay",
       description: "Seconds until switch/motion toggles off (10 - 120)",
       range: "10..120", defaultValue: 10, required: true
+    input name: "inactiveEnable", type: "bool", title: "Enable automatic inactivity",
+      defaultValue: true
     input name: "logEnable", type: "bool", title: "Enable Logging",
       defaultValue: false
   }
@@ -49,7 +51,7 @@ def on() {
   if (logEnable) { log.info "$device.displayName active" }
   sendEvent(name: "motion", value: "active")
   sendEvent(name: "switch", value: "on")
-  runIn(inactiveSeconds, "off")
+  if (inactiveEnable) { runIn(inactiveSeconds, "off") }
 }
 
 def off() {


### PR DESCRIPTION
I added a simple boolean check to disable or enable the automatic inactive state after a user-specified amount of time. I did this since in Alexa I have routines for both when the "switch" is off and when it is on.