### PR TITLE
Small bug fixes

### DIFF
--- a/drivers/leviton-decora-dimmer.groovy
+++ b/drivers/leviton-decora-dimmer.groovy
@@ -56,10 +56,10 @@ metadata {
         description: "0 to 100 (default 100)", range: "0..100",
         displayDuringSetup: false, required: false
     input name: "fadeOnTime", type: "number", title: "Fade-on time",
-        description: "0 to 253 (default 2)\n0 = instant on\n1 - 127 = 1 - 127 seconds\n128 - 253 = 1 - 126 minutes", range: "0..253",
+        description: "0 to 253 (default 2)<br>0 = instant on<br>1 - 127 = 1 - 127 seconds<br>128 - 253 = 1 - 126 minutes", range: "0..253",
         displayDuringSetup: false, required: false
     input name: "fadeOffTime", type: "number", title: "Fade-off time",
-        description: "0 to 253 (default 2)\n0 = instant off\n1 - 127 = 1 - 127 seconds\n128 - 253 = 1 - 126 minutes", range: "0..253",
+        description: "0 to 253 (default 2)<br>0 = instant off<br>1 - 127 = 1 - 127 seconds<br>128 - 253 = 1 - 126 minutes", range: "0..253",
         displayDuringSetup: false, required: false
     input name: "levelIndicatorTimeout", type: "number", title: "Dim level indicator timeout",
         description: "0 to 255 (default 3)", range: "0..255",

--- a/drivers/leviton-decora-dimmer.groovy
+++ b/drivers/leviton-decora-dimmer.groovy
@@ -129,7 +129,7 @@ def on() {
   state.lastDigital = now()
   def fadeOnTime = device.currentValue("fadeOnTime")
   def presetLevel = device.currentValue("presetLevel")
-  short duration = fadeOnTime == null ? 255 : fadeOnTime
+  short duration = fadeOnTime == null ? 2 : durationToSeconds(fadeOnTime.shortValue())
   short level = presetLevel == null || presetLevel == 0 ? 0xFF : toZwaveLevel(presetLevel as short)
   if (level != 0xFF) {
     def displayLevel = toDisplayLevel(level)
@@ -149,7 +149,7 @@ def on() {
 def off() {
   state.lastDigital = now()
   def fadeOffTime = device.currentValue("fadeOffTime")
-  short duration = fadeOffTime == null ? 255 : fadeOffTime
+  short duration = fadeOffTime == null ? 2 : durationToSeconds(fadeOffTime.shortValue())
   if (device.currentValue("level") != 0) {
     sendEvent(name: "level", value: 0, unit: "%", descriptionText: "Level set to 0% [$eventType]", type: eventType)
   }
@@ -167,7 +167,7 @@ def setLevel(value, duration = null) {
   if (logEnable) log.debug "setLevel: $value"
 
   short level = toDisplayLevel(value as short)
-  short dimmingDuration = durationSeconds == null ? 255 : secondsToDuration(durationSeconds as int)
+  short dimmingDuration = duration == null ? 2 : duration
   String switchState = level == 0 ? "off" : "on"
 
   if (level != device.currentValue("level")) {

--- a/drivers/leviton-decora-plug-in-dimmer.groovy
+++ b/drivers/leviton-decora-plug-in-dimmer.groovy
@@ -142,7 +142,12 @@ def setLevel(value, duration = null) {
   if (logEnable) log.debug "setLevel: $value"
 
   short level = toDisplayLevel(value as short)
-  short dimmingDuration = duration == null ? 2 : duration
+  short dimmingDuration
+  if (!duration) {
+    dimmingDuration = (device.currentValue("switch") == "on" && device.currentValue("level") > value) ? durationToSeconds(fadeOffTime.shortValue()) : durationToSeconds(fadeOnTime.shortValue())
+  } else {
+    dimmingDuration = duration
+  }
   String switchState = level == 0 ? "off" : "on"
 
   if (level != device.currentValue("level")) {

--- a/drivers/leviton-decora-plug-in-dimmer.groovy
+++ b/drivers/leviton-decora-plug-in-dimmer.groovy
@@ -50,10 +50,10 @@ metadata {
         description: "0 to 100 (default 100)", range: "0..100",
         displayDuringSetup: false, required: false
     input name: "fadeOnTime", type: "number", title: "Fade-on time",
-        description: "0 to 253 (default 2)\n0 = instant on\n1 - 127 = 1 - 127 seconds\n128 - 253 = 1 - 126 minutes", range: "0..253",
+        description: "0 to 253 (default 2)<br>0 = instant on<br>1 - 127 = 1 - 127 seconds<br>128 - 253 = 1 - 126 minutes", range: "0..253",
         displayDuringSetup: false, required: false
     input name: "fadeOffTime", type: "number", title: "Fade-off time",
-        description: "0 to 253 (default 2)\n0 = instant off\n1 - 127 = 1 - 127 seconds\n128 - 253 = 1 - 126 minutes", range: "0..253",
+        description: "0 to 253 (default 2)<br>0 = instant off<br>1 - 127 = 1 - 127 seconds<br>128 - 253 = 1 - 126 minutes", range: "0..253",
         displayDuringSetup: false, required: false
     input name: "logEnable", type: "bool", title: "Enable debug logging", defaultValue: false
   }

--- a/drivers/leviton-decora-plug-in-dimmer.groovy
+++ b/drivers/leviton-decora-plug-in-dimmer.groovy
@@ -113,7 +113,7 @@ def parse(String description) {
 def on() {
   state.lastDigital = now()
   def fadeOnTime = device.currentValue("fadeOnTime")
-  short duration = fadeOnTime == null ? 255 : fadeOnTime
+  short duration = fadeOnTime == null ? 2 : durationToSeconds(fadeOnTime.shortValue())
   if (device.currentValue("switch") != "on") {
     sendEvent(name: "switch", value: "on", descriptionText: "Switch turned on [$eventType]", type: eventType)
   }
@@ -125,7 +125,7 @@ def on() {
 def off() {
   state.lastDigital = now()
   def fadeOffTime = device.currentValue("fadeOffTime")
-  short duration = fadeOffTime == null ? 255 : fadeOffTime
+  short duration = fadeOffTime == null ? 2 : durationToSeconds(fadeOffTime.shortValue())
   if (device.currentValue("level") != 0) {
     sendEvent(name: "level", value: 0, unit: "%", descriptionText: "Level set to 0% [$eventType]", type: eventType)
   }
@@ -142,7 +142,7 @@ def setLevel(value, duration = null) {
   if (logEnable) log.debug "setLevel: $value"
 
   short level = toDisplayLevel(value as short)
-  short dimmingDuration = durationSeconds == null ? 255 : secondsToDuration(durationSeconds as int)
+  short dimmingDuration = duration == null ? 2 : duration
   String switchState = level == 0 ? "off" : "on"
 
   if (level != device.currentValue("level")) {

--- a/drivers/package-manifests/leviton-decora-dimmer.json
+++ b/drivers/package-manifests/leviton-decora-dimmer.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Leviton Decora Smart Z-Wave Dimmer",
   "author": "Ernie Miller",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "minimumHEVersion": "2.2.3",
   "dateReleased": "2020-12-02",
   "drivers": [

--- a/drivers/package-manifests/leviton-decora-dimmer.json
+++ b/drivers/package-manifests/leviton-decora-dimmer.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Leviton Decora Smart Z-Wave Dimmer",
   "author": "Ernie Miller",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "minimumHEVersion": "2.2.3",
   "dateReleased": "2020-12-02",
   "drivers": [

--- a/drivers/package-manifests/leviton-decora-plug-in-dimmer.json
+++ b/drivers/package-manifests/leviton-decora-plug-in-dimmer.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Leviton Decora Smart Z-Wave Plug-In Dimmer",
   "author": "Ernie Miller",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "minimumHEVersion": "2.2.3",
   "dateReleased": "2020-12-02",
   "drivers": [

--- a/drivers/package-manifests/leviton-decora-plug-in-dimmer.json
+++ b/drivers/package-manifests/leviton-decora-plug-in-dimmer.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Leviton Decora Smart Z-Wave Plug-In Dimmer",
   "author": "Ernie Miller",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "minimumHEVersion": "2.2.3",
   "dateReleased": "2020-12-02",
   "drivers": [

--- a/drivers/package-manifests/leviton-decora-plug-in-dimmer.json
+++ b/drivers/package-manifests/leviton-decora-plug-in-dimmer.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Leviton Decora Smart Z-Wave Plug-In Dimmer",
   "author": "Ernie Miller",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "minimumHEVersion": "2.2.3",
   "dateReleased": "2020-12-02",
   "drivers": [


### PR DESCRIPTION
This fixes:

1. Fade duration did not seem to be obeyed on either driver when I tested it, so I fixed some references to undefined variables.
2. On my Hubitat the "\n" character was not making a new line on the preferences area, so I replaced the character with "< br >"
3. SetLevel() behaves differently on the DZPD3-2BW than the other Leviton devices I have (DZ6HD, DZ1KD, and DW3HL-1BW). On other Leviton devices, the FadeOn/FadeOff times are used when running SetLevel without a duration, on the DZPD3-2BW it uses 2 seconds and ignores the fade times if no duration is listed. I think that there is actually a firmware bug on the DZPD3-2BW causing the issue, but I was able to mimic the behavior via the driver.